### PR TITLE
[feature/domain-recruit] 구인 도메인 CRUD 및 Pagination 구현

### DIFF
--- a/src/main/java/org/hifivee/minebackend/MineBackendApplication.java
+++ b/src/main/java/org/hifivee/minebackend/MineBackendApplication.java
@@ -2,7 +2,9 @@ package org.hifivee.minebackend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class MineBackendApplication {
 

--- a/src/main/java/org/hifivee/minebackend/domain/account/controller/AccountController.java
+++ b/src/main/java/org/hifivee/minebackend/domain/account/controller/AccountController.java
@@ -27,7 +27,7 @@ public class AccountController {
             return ResponseEntity.ok(new AccountCreateResponseDto(dtoMetaData));
         } catch (Exception e) {
             dtoMetaData = new DtoMetaData(e.getMessage(), e.getClass().getName());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new AccountCreateResponseDto(dtoMetaData));
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new AccountCreateResponseDto(dtoMetaData));
         }
     }
 
@@ -42,7 +42,7 @@ public class AccountController {
             return ResponseEntity.ok(new AccountFetchResponseDto(dtoMetaData, account));
         } catch (Exception e) {
             dtoMetaData = new DtoMetaData(e.getMessage(), e.getClass().getName());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new AccountFetchResponseDto(dtoMetaData));
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new AccountFetchResponseDto(dtoMetaData));
         }
     }
 
@@ -57,7 +57,7 @@ public class AccountController {
             return ResponseEntity.ok(new AccountUpdateResponseDto(dtoMetaData));
         } catch (Exception e) {
             dtoMetaData = new DtoMetaData(e.getMessage(), e.getClass().getName());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new AccountUpdateResponseDto(dtoMetaData));
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new AccountUpdateResponseDto(dtoMetaData));
         }
     }
 
@@ -72,7 +72,7 @@ public class AccountController {
             return ResponseEntity.ok(new AccountPasswordUpdateResponseDto(dtoMetaData));
         } catch (Exception e) {
             dtoMetaData = new DtoMetaData(e.getMessage(), e.getClass().getName());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new AccountPasswordUpdateResponseDto(dtoMetaData));
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new AccountPasswordUpdateResponseDto(dtoMetaData));
         }
     }
 
@@ -87,7 +87,7 @@ public class AccountController {
             return ResponseEntity.ok(new AccountDeleteResponseDto(dtoMetaData));
         } catch (Exception e) {
             dtoMetaData = new DtoMetaData(e.getMessage(), e.getClass().getName());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new AccountDeleteResponseDto(dtoMetaData));
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new AccountDeleteResponseDto(dtoMetaData));
         }
     }
 }

--- a/src/main/java/org/hifivee/minebackend/domain/account/dto/AccountCreateRequestDto.java
+++ b/src/main/java/org/hifivee/minebackend/domain/account/dto/AccountCreateRequestDto.java
@@ -11,7 +11,7 @@ public class AccountCreateRequestDto {
     private String email;
     private String password;
 
-    public Account toAccount(PasswordEncoder passwordEncoder) {
+    public Account toEntity(PasswordEncoder passwordEncoder) {
         return Account.builder()
                 .email(email)
                 .password(passwordEncoder.encode(password))

--- a/src/main/java/org/hifivee/minebackend/domain/account/repository/Account.java
+++ b/src/main/java/org/hifivee/minebackend/domain/account/repository/Account.java
@@ -3,6 +3,7 @@ package org.hifivee.minebackend.domain.account.repository;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hifivee.minebackend.global.entity.BaseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.persistence.*;
@@ -10,7 +11,7 @@ import javax.persistence.*;
 @Getter
 @NoArgsConstructor
 @Entity
-public class Account {
+public class Account extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/hifivee/minebackend/domain/account/service/AccountService.java
+++ b/src/main/java/org/hifivee/minebackend/domain/account/service/AccountService.java
@@ -25,7 +25,7 @@ public class AccountService {
         }
 
         // 계정 생성: 기본 정보 DB 에 저장 (패스워드는 인코딩하여 저장)
-        accountRepository.save(requestDto.toAccount(passwordEncoder));
+        accountRepository.save(requestDto.toEntity(passwordEncoder));
     }
 
     @Transactional

--- a/src/main/java/org/hifivee/minebackend/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/org/hifivee/minebackend/domain/recruit/controller/RecruitController.java
@@ -1,0 +1,87 @@
+package org.hifivee.minebackend.domain.recruit.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.hifivee.minebackend.domain.recruit.dto.*;
+import org.hifivee.minebackend.domain.recruit.service.RecruitService;
+import org.hifivee.minebackend.global.dto.DtoMetaData;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/recruit")
+@RestController
+public class RecruitController {
+
+    private final RecruitService recruitService;
+
+    @PostMapping
+    public ResponseEntity<RecruitCreateResponseDto> createRecruit(@RequestBody RecruitCreateRequestDto requestDto) {
+        DtoMetaData dtoMetaData;
+
+        try {
+            recruitService.createRecruit(requestDto);
+            dtoMetaData = new DtoMetaData("구인 정보 생성 성공");
+            return ResponseEntity.ok(new RecruitCreateResponseDto(dtoMetaData));
+        }
+       catch (Exception e) {
+            dtoMetaData = new DtoMetaData(e.getMessage(), e.getClass().getName());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new RecruitCreateResponseDto(dtoMetaData));
+        }
+    }
+
+    @GetMapping
+    public ResponseEntity<RecruitFetchResponseDto> fetchRecruit(@RequestBody RecruitFetchRequestDto requestDto) {
+        DtoMetaData dtoMetaData;
+
+        try {
+            RecruitFetchResponseDto responseDto;
+
+            if(requestDto.getId() != null) {
+                responseDto = recruitService.fetchRecruit(requestDto);
+            }
+            else {
+                responseDto = recruitService.fetchAllRecruit(requestDto);
+            }
+
+            dtoMetaData = new DtoMetaData("구인 정보 가져오기 성공");
+            responseDto.setDtoMetaData(dtoMetaData);
+
+            return ResponseEntity.ok(responseDto);
+        }
+        catch (Exception e) {
+            dtoMetaData = new DtoMetaData(e.getMessage(), e.getClass().getName());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new RecruitFetchResponseDto(dtoMetaData));
+        }
+    }
+
+    @PutMapping
+    public ResponseEntity<RecruitUpdateResponseDto> updateRecruit(@RequestBody RecruitUpdateRequestDto requestDto) {
+        DtoMetaData dtoMetaData;
+
+        try {
+            recruitService.updateRecruit(requestDto);
+            dtoMetaData = new DtoMetaData("구인 정보 업데이트 성공");
+            return ResponseEntity.ok(new RecruitUpdateResponseDto(dtoMetaData));
+        }
+        catch (Exception e) {
+            dtoMetaData = new DtoMetaData(e.getMessage(), e.getClass().getName());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new RecruitUpdateResponseDto(dtoMetaData));
+        }
+    }
+
+    @DeleteMapping
+    public ResponseEntity<RecruitDeleteResponseDto> deleteRecruit(@RequestBody RecruitDeleteRequestDto requestDto) {
+        DtoMetaData dtoMetaData;
+
+        try {
+            recruitService.deleteRecruit(requestDto);
+            dtoMetaData = new DtoMetaData("구인 정보 삭제 성공");
+            return ResponseEntity.ok(new RecruitDeleteResponseDto(dtoMetaData));
+        }
+        catch (Exception e) {
+            dtoMetaData = new DtoMetaData(e.getMessage(), e.getClass().getName());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new RecruitDeleteResponseDto(dtoMetaData));
+        }
+    }
+}

--- a/src/main/java/org/hifivee/minebackend/domain/recruit/dto/RecruitCreateRequestDto.java
+++ b/src/main/java/org/hifivee/minebackend/domain/recruit/dto/RecruitCreateRequestDto.java
@@ -1,0 +1,24 @@
+package org.hifivee.minebackend.domain.recruit.dto;
+
+import lombok.Data;
+import org.hifivee.minebackend.domain.recruit.repository.Recruit;
+
+@Data
+public class RecruitCreateRequestDto {
+
+    private Long projectId;
+    private String description;
+    private String attachments;
+    private Integer openings;
+    private String applicants;
+
+    public Recruit toEntity() {
+        return Recruit.builder()
+                .projectId(projectId)
+                .description(description)
+                .attachments(attachments)
+                .openings(openings)
+                .applicants(applicants)
+                .build();
+    }
+}

--- a/src/main/java/org/hifivee/minebackend/domain/recruit/dto/RecruitCreateResponseDto.java
+++ b/src/main/java/org/hifivee/minebackend/domain/recruit/dto/RecruitCreateResponseDto.java
@@ -1,0 +1,12 @@
+package org.hifivee.minebackend.domain.recruit.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.hifivee.minebackend.global.dto.DtoMetaData;
+
+@Data
+@AllArgsConstructor
+public class RecruitCreateResponseDto {
+
+    private DtoMetaData dtoMetaData;
+}

--- a/src/main/java/org/hifivee/minebackend/domain/recruit/dto/RecruitDeleteRequestDto.java
+++ b/src/main/java/org/hifivee/minebackend/domain/recruit/dto/RecruitDeleteRequestDto.java
@@ -1,0 +1,9 @@
+package org.hifivee.minebackend.domain.recruit.dto;
+
+import lombok.Data;
+
+@Data
+public class RecruitDeleteRequestDto {
+
+    private Long id;
+}

--- a/src/main/java/org/hifivee/minebackend/domain/recruit/dto/RecruitDeleteResponseDto.java
+++ b/src/main/java/org/hifivee/minebackend/domain/recruit/dto/RecruitDeleteResponseDto.java
@@ -1,0 +1,12 @@
+package org.hifivee.minebackend.domain.recruit.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.hifivee.minebackend.global.dto.DtoMetaData;
+
+@Data
+@AllArgsConstructor
+public class RecruitDeleteResponseDto {
+
+    private DtoMetaData dtoMetaData;
+}

--- a/src/main/java/org/hifivee/minebackend/domain/recruit/dto/RecruitFetchRequestDto.java
+++ b/src/main/java/org/hifivee/minebackend/domain/recruit/dto/RecruitFetchRequestDto.java
@@ -1,0 +1,11 @@
+package org.hifivee.minebackend.domain.recruit.dto;
+
+import lombok.Data;
+
+@Data
+public class RecruitFetchRequestDto {
+
+    private Long id;
+    private Integer pageIndex;
+    private Long topId;
+}

--- a/src/main/java/org/hifivee/minebackend/domain/recruit/dto/RecruitFetchResponseDto.java
+++ b/src/main/java/org/hifivee/minebackend/domain/recruit/dto/RecruitFetchResponseDto.java
@@ -1,0 +1,43 @@
+package org.hifivee.minebackend.domain.recruit.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hifivee.minebackend.domain.recruit.repository.Recruit;
+import org.hifivee.minebackend.global.dto.DtoMetaData;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+@Setter
+@NoArgsConstructor
+@Data
+public class RecruitFetchResponseDto {
+
+    private DtoMetaData dtoMetaData;
+    private List<Recruit> recruitList;
+    private Pageable pageable;
+    private Boolean isLast;
+
+    public RecruitFetchResponseDto(List<Recruit> recruitList) {
+        this.dtoMetaData = null;
+        this.recruitList = recruitList;
+        this.pageable = null;
+        this.isLast = null;
+    }
+
+    public RecruitFetchResponseDto(List<Recruit> recruitList, Pageable pageable, Boolean isLast) {
+        this.dtoMetaData = null;
+        this.recruitList = recruitList;
+        this.pageable = pageable;
+        this.isLast = isLast;
+    }
+
+    public RecruitFetchResponseDto(DtoMetaData dtoMetaData) {
+        this.dtoMetaData = dtoMetaData;
+        this.recruitList = null;
+        this.pageable = null;
+        this.isLast = null;
+    }
+}

--- a/src/main/java/org/hifivee/minebackend/domain/recruit/dto/RecruitUpdateRequestDto.java
+++ b/src/main/java/org/hifivee/minebackend/domain/recruit/dto/RecruitUpdateRequestDto.java
@@ -1,0 +1,14 @@
+package org.hifivee.minebackend.domain.recruit.dto;
+
+import lombok.Data;
+
+@Data
+public class RecruitUpdateRequestDto {
+
+    private Long id;
+    private Long projectId;
+    private String description;
+    private String attachments;
+    private Integer openings;
+    private String applicants;
+}

--- a/src/main/java/org/hifivee/minebackend/domain/recruit/dto/RecruitUpdateResponseDto.java
+++ b/src/main/java/org/hifivee/minebackend/domain/recruit/dto/RecruitUpdateResponseDto.java
@@ -1,0 +1,12 @@
+package org.hifivee.minebackend.domain.recruit.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.hifivee.minebackend.global.dto.DtoMetaData;
+
+@Data
+@AllArgsConstructor
+public class RecruitUpdateResponseDto {
+
+    private DtoMetaData dtoMetaData;
+}

--- a/src/main/java/org/hifivee/minebackend/domain/recruit/repository/Recruit.java
+++ b/src/main/java/org/hifivee/minebackend/domain/recruit/repository/Recruit.java
@@ -1,0 +1,43 @@
+package org.hifivee.minebackend.domain.recruit.repository;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hifivee.minebackend.global.entity.BaseEntity;
+
+import javax.persistence.*;
+
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Recruit extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private Long projectId;
+    private String description;
+    private String attachments;
+    private Integer openings;
+    private String applicants;
+
+    @Builder
+    public Recruit(Long projectId, String description, String attachments, Integer openings, String applicants) {
+        this.projectId = projectId;
+        this.description = description;
+        this.attachments = attachments;
+        this.openings = openings;
+        this.applicants = applicants;
+    }
+
+    public void update(Long projectId, String description, String attachments, Integer openings, String applicants) {
+        this.projectId = projectId;
+        this.description = description;
+        this.attachments = attachments;
+        this.openings = openings;
+        this.applicants = applicants;
+    }
+}

--- a/src/main/java/org/hifivee/minebackend/domain/recruit/repository/RecruitRepository.java
+++ b/src/main/java/org/hifivee/minebackend/domain/recruit/repository/RecruitRepository.java
@@ -1,0 +1,27 @@
+package org.hifivee.minebackend.domain.recruit.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RecruitRepository extends JpaRepository<Recruit, Long> {
+
+    Boolean existsByProjectId(Long projectId);
+    Optional<Recruit> findById(Long id);
+    Page<Recruit> findAll(Pageable pageable);
+
+    @Query(
+            value = "SELECT * FROM recruit AS r WHERE r.id <= :topId",
+            countQuery = "SELECT COUNT(*) FROM recruit AS r WHERE r.id <= :topId",
+            nativeQuery = true
+    )
+    Page<Recruit> findAllByTopRecruitId(
+            @Param("topId") Long topId,
+            Pageable pageable);
+}

--- a/src/main/java/org/hifivee/minebackend/domain/recruit/service/RecruitService.java
+++ b/src/main/java/org/hifivee/minebackend/domain/recruit/service/RecruitService.java
@@ -1,0 +1,93 @@
+package org.hifivee.minebackend.domain.recruit.service;
+
+import lombok.RequiredArgsConstructor;
+import org.hifivee.minebackend.domain.recruit.dto.*;
+import org.hifivee.minebackend.domain.recruit.repository.Recruit;
+import org.hifivee.minebackend.domain.recruit.repository.RecruitRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class RecruitService {
+
+    private final RecruitRepository recruitRepository;
+
+    @Transactional
+    public void createRecruit(RecruitCreateRequestDto requestDto) {
+        // 기존 프로젝트로 구인글이 생성되어 있는지 확인
+        Long projectId = requestDto.getProjectId();
+        if(recruitRepository.existsByProjectId(projectId)) {
+            throw new IllegalArgumentException("이미 해당 프로젝트로 구인글이 생성되어 있습니다. projectId: " + projectId);
+        }
+
+        recruitRepository.save(requestDto.toEntity());
+    }
+
+    @Transactional(readOnly = true)
+    public RecruitFetchResponseDto fetchRecruit(RecruitFetchRequestDto requestDto) {
+        // 해당 id를 가진 구인글 가져오기
+        Long id = requestDto.getId();
+        Recruit recruit = recruitRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 구인글이 존재하지 않습니다. id: " + id));
+
+        // 구인글 리스트에 추가하기
+        List<Recruit> recruitList = new ArrayList<>();
+        recruitList.add(recruit);
+
+        return new RecruitFetchResponseDto(recruitList);
+    }
+
+    @Transactional(readOnly = true)
+    public RecruitFetchResponseDto fetchAllRecruit(RecruitFetchRequestDto requestDto) {
+        Page<Recruit> recruitPage;
+
+        // 페이지 당 10개 가져오기
+        int RECRUIT_PER_PAGE = 10;
+
+        // 요청된 정보를 기반으로 Pageable 객체 생성
+        int pageIndex = requestDto.getPageIndex() == null ? 0 : requestDto.getPageIndex();
+        Pageable pageable = PageRequest.of(pageIndex, RECRUIT_PER_PAGE, Sort.Direction.DESC, "id");
+
+        Long topId = requestDto.getTopId();
+        if(topId == null) {
+            recruitPage = recruitRepository.findAll(pageable);
+        } else {
+            recruitPage = recruitRepository.findAllByTopRecruitId(topId, pageable);
+        }
+
+        return new RecruitFetchResponseDto(recruitPage.getContent(), recruitPage.getPageable(), recruitPage.isLast());
+    }
+
+    @Transactional
+    public void updateRecruit(RecruitUpdateRequestDto requestDto) {
+        // 구인글 정보 가져오기
+        Long id = requestDto.getId();
+        Recruit recruit = recruitRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 구인글이 존재하지 않습니다. id: " + id));
+
+        // 구인글 업데이트 하기
+        recruit.update(requestDto.getProjectId(), requestDto.getDescription(),
+                requestDto.getAttachments(), requestDto.getOpenings(), requestDto.getApplicants());
+
+        recruitRepository.save(recruit);
+    }
+
+    @Transactional
+    public void deleteRecruit(RecruitDeleteRequestDto requestDto) {
+        // 구인글 정보 가져오기
+        Long id = requestDto.getId();
+        Recruit recruit = recruitRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 구인글이 존재하지 않습니다. id: " + id));
+
+        // 구인글 삭제하기
+        recruitRepository.delete(recruit);
+    }
+}

--- a/src/main/java/org/hifivee/minebackend/global/dto/DtoMetaData.java
+++ b/src/main/java/org/hifivee/minebackend/global/dto/DtoMetaData.java
@@ -1,6 +1,5 @@
 package org.hifivee.minebackend.global.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data

--- a/src/main/java/org/hifivee/minebackend/global/entity/BaseEntity.java
+++ b/src/main/java/org/hifivee/minebackend/global/entity/BaseEntity.java
@@ -1,0 +1,21 @@
+package org.hifivee.minebackend.global.entity;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class BaseEntity {
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedDate;
+}


### PR DESCRIPTION
## 개요
### PR 종류
 - [x] 기능 구현을 위한 소스코드 수정 (PR제목 양식: "[feature/브랜치명] 제목", 브랜치작명법: "feature/명칭" 사용)
 - [ ] 버그 수정을 위한 소스코드 수정 (PR제목 양식: "[hotfix/브랜치명] 제목", 브랜치작명법: "hotfix/명칭" 사용)

## 작업내용
- 구인 도메인의 기본 CRUD 및 Pagination을 구현하였습니다.

## 변경사항
 - Recruit Domain
   - REST API 설계 가이드라인을 바탕으로 Recruit CRUD API 엔드포인트를 구현하였습니다.
     - 구인(글) 생성 (POST)
     - 구인(글) 읽기 (GET)
       - Pagination이 구현되어 있습니다. 자세한 사항은 Postman의 example를 확인해주세요. 
     - 구인(글) 수정 (PUT)
     - 구인(글) 삭제 (DELETE)
- Global Domain
  - Entity의 생성 시간과 변경 시간을 자동으로 기록하는 BaseEntity 추상 클래스를 생성하였습니다. 
  -  앞으로 모든 Entity들은 BaseEntity를 상속 받습니다.
 
## 비고
- Postman에 관련 테스트를 추가하였습니다.
  - Recruit 폴더 참고 