### PR TITLE
[feature/apply-domain-api]지원서 도메인 CRUD 구현

### DIFF
--- a/src/main/java/org/hifivee/minebackend/domain/apply/controller/ApplyController.java
+++ b/src/main/java/org/hifivee/minebackend/domain/apply/controller/ApplyController.java
@@ -1,10 +1,60 @@
 package org.hifivee.minebackend.domain.apply.controller;
 
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import lombok.RequiredArgsConstructor;
+import org.apache.coyote.Response;
+import org.hifivee.minebackend.domain.apply.dto.ApplyCreateRequestDto;
+import org.hifivee.minebackend.domain.apply.dto.ApplyCreateResponseDto;
+import org.hifivee.minebackend.domain.apply.dto.ApplyFetchRequestDto;
+import org.hifivee.minebackend.domain.apply.dto.ApplyFetchResponseDto;
+import org.hifivee.minebackend.domain.apply.repository.Apply;
+import org.hifivee.minebackend.domain.apply.service.ApplyService;
+import org.hifivee.minebackend.global.dto.DtoMetaData;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequestMapping("/api/apply")
+@RequiredArgsConstructor
 @RestController
 public class ApplyController {
+    private final ApplyService applyService;
+
+    @PostMapping
+    public ResponseEntity<ApplyCreateResponseDto> createApply(@RequestBody ApplyCreateRequestDto requestDto) {
+        DtoMetaData dtoMetaData;
+        try {
+            applyService.createApply(requestDto);
+            dtoMetaData = new DtoMetaData("지원서 작성 성공");
+            return ResponseEntity.ok(new ApplyCreateResponseDto(dtoMetaData));
+        } catch (Exception e) {
+            dtoMetaData = new DtoMetaData(e.getMessage(), e.getClass().getName());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApplyCreateResponseDto(dtoMetaData));
+        }
+    }
+
+    @GetMapping
+    public ResponseEntity<ApplyFetchResponseDto> fetchApply(@RequestBody ApplyFetchRequestDto requestDto){
+        DtoMetaData dtoMetaData;
+        List<Apply> applies;
+        try{
+            if(requestDto.getRecruitId() != null){
+                applies = applyService.fetchRecuritApply(requestDto);
+                dtoMetaData = new DtoMetaData("해당 구인글에 대한 지원서 조회 성공");
+            }
+            else if(requestDto.getUserId() != null){
+                applies = applyService.fetchMyApply(requestDto);
+                dtoMetaData = new DtoMetaData("나의 지원서 조회 성공");
+            }
+            else {
+                applies = applyService.fetchApply(requestDto);
+                dtoMetaData = new DtoMetaData("지원서 조회 성공");
+            }
+            return ResponseEntity.ok(new ApplyFetchResponseDto(dtoMetaData, applies));
+        } catch (Exception e){
+            dtoMetaData = new DtoMetaData(e.getMessage(), e.getClass().getName());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApplyFetchResponseDto(dtoMetaData));
+        }
+    }
 }

--- a/src/main/java/org/hifivee/minebackend/domain/apply/controller/ApplyController.java
+++ b/src/main/java/org/hifivee/minebackend/domain/apply/controller/ApplyController.java
@@ -1,11 +1,8 @@
 package org.hifivee.minebackend.domain.apply.controller;
 
+import lombok.Data;
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.Response;
-import org.hifivee.minebackend.domain.apply.dto.ApplyCreateRequestDto;
-import org.hifivee.minebackend.domain.apply.dto.ApplyCreateResponseDto;
-import org.hifivee.minebackend.domain.apply.dto.ApplyFetchRequestDto;
-import org.hifivee.minebackend.domain.apply.dto.ApplyFetchResponseDto;
+import org.hifivee.minebackend.domain.apply.dto.*;
 import org.hifivee.minebackend.domain.apply.repository.Apply;
 import org.hifivee.minebackend.domain.apply.service.ApplyService;
 import org.hifivee.minebackend.global.dto.DtoMetaData;
@@ -55,6 +52,34 @@ public class ApplyController {
         } catch (Exception e){
             dtoMetaData = new DtoMetaData(e.getMessage(), e.getClass().getName());
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApplyFetchResponseDto(dtoMetaData));
+        }
+    }
+
+    @DeleteMapping
+    public ResponseEntity<ApplyDeleteResponseDto> deleteApply(@RequestBody ApplyDeleteRequestDto requestDto){
+        DtoMetaData dtoMetaData;
+        try{
+            applyService.deleteApply(requestDto);
+            dtoMetaData = new DtoMetaData("지원서 삭제 성공");
+            return ResponseEntity.ok(new ApplyDeleteResponseDto((dtoMetaData)));
+        }
+        catch (Exception e){
+            dtoMetaData = new DtoMetaData(e.getMessage(), e.getClass().getName());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApplyDeleteResponseDto(dtoMetaData));
+        }
+    }
+
+    @PutMapping
+    public ResponseEntity<ApplyUpdateResponseDto> updateApply(@RequestBody ApplyUpdateRequestDto requestDto){
+        DtoMetaData dtoMetaData;
+        try{
+            applyService.updateApply(requestDto);
+            dtoMetaData = new DtoMetaData("지원서 수정 성공");
+            return ResponseEntity.ok(new ApplyUpdateResponseDto(dtoMetaData));
+        }
+        catch (Exception e){
+            dtoMetaData = new DtoMetaData(e.getMessage(), e.getClass().getName());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApplyUpdateResponseDto(dtoMetaData));
         }
     }
 }

--- a/src/main/java/org/hifivee/minebackend/domain/apply/controller/ApplyController.java
+++ b/src/main/java/org/hifivee/minebackend/domain/apply/controller/ApplyController.java
@@ -1,0 +1,10 @@
+package org.hifivee.minebackend.domain.apply.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/apply")
+@RestController
+public class ApplyController {
+}

--- a/src/main/java/org/hifivee/minebackend/domain/apply/dto/ApplyCreateRequestDto.java
+++ b/src/main/java/org/hifivee/minebackend/domain/apply/dto/ApplyCreateRequestDto.java
@@ -1,0 +1,10 @@
+package org.hifivee.minebackend.domain.apply.dto;
+
+import lombok.Data;
+
+@Data
+public class ApplyCreateRequestDto {
+    private Long userId;
+    private String applyMessage;
+    private Long recruitId;
+}

--- a/src/main/java/org/hifivee/minebackend/domain/apply/dto/ApplyCreateRequestDto.java
+++ b/src/main/java/org/hifivee/minebackend/domain/apply/dto/ApplyCreateRequestDto.java
@@ -1,10 +1,21 @@
 package org.hifivee.minebackend.domain.apply.dto;
 
 import lombok.Data;
+import org.hifivee.minebackend.domain.account.repository.Account;
+import org.hifivee.minebackend.domain.apply.repository.Apply;
+import org.hifivee.minebackend.domain.recruit.repository.Recruit;
 
 @Data
 public class ApplyCreateRequestDto {
     private Long userId;
     private String applyMessage;
     private Long recruitId;
+
+    public Apply toApply(Account userId, Recruit recruitId){
+        return Apply.builder()
+                .account(userId)
+                .applyMessage(applyMessage)
+                .recruit(recruitId)
+                .build();
+    }
 }

--- a/src/main/java/org/hifivee/minebackend/domain/apply/dto/ApplyCreateResponseDto.java
+++ b/src/main/java/org/hifivee/minebackend/domain/apply/dto/ApplyCreateResponseDto.java
@@ -1,7 +1,11 @@
 package org.hifivee.minebackend.domain.apply.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import org.hifivee.minebackend.global.dto.DtoMetaData;
 
 @Data
+@AllArgsConstructor
 public class ApplyCreateResponseDto {
+    private DtoMetaData dtoMetaData;
 }

--- a/src/main/java/org/hifivee/minebackend/domain/apply/dto/ApplyCreateResponseDto.java
+++ b/src/main/java/org/hifivee/minebackend/domain/apply/dto/ApplyCreateResponseDto.java
@@ -1,0 +1,7 @@
+package org.hifivee.minebackend.domain.apply.dto;
+
+import lombok.Data;
+
+@Data
+public class ApplyCreateResponseDto {
+}

--- a/src/main/java/org/hifivee/minebackend/domain/apply/dto/ApplyDeleteRequestDto.java
+++ b/src/main/java/org/hifivee/minebackend/domain/apply/dto/ApplyDeleteRequestDto.java
@@ -1,0 +1,8 @@
+package org.hifivee.minebackend.domain.apply.dto;
+
+import lombok.Data;
+
+@Data
+public class ApplyDeleteRequestDto {
+    private Long id;
+}

--- a/src/main/java/org/hifivee/minebackend/domain/apply/dto/ApplyDeleteResponseDto.java
+++ b/src/main/java/org/hifivee/minebackend/domain/apply/dto/ApplyDeleteResponseDto.java
@@ -1,0 +1,11 @@
+package org.hifivee.minebackend.domain.apply.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.hifivee.minebackend.global.dto.DtoMetaData;
+
+@Data
+@AllArgsConstructor
+public class ApplyDeleteResponseDto {
+    private DtoMetaData dtoMetaData;
+}

--- a/src/main/java/org/hifivee/minebackend/domain/apply/dto/ApplyFetchRequestDto.java
+++ b/src/main/java/org/hifivee/minebackend/domain/apply/dto/ApplyFetchRequestDto.java
@@ -1,0 +1,20 @@
+package org.hifivee.minebackend.domain.apply.dto;
+
+import lombok.Data;
+import org.hifivee.minebackend.domain.account.repository.Account;
+
+@Data
+public class ApplyFetchRequestDto {
+    // 특정 지원서
+    //private long id;
+
+    // 나의 지원서
+    //private Long userId;
+
+    // 구인글별 지원서
+    //private Long recruitId;
+
+    private long id;
+    private Long userId;
+    private Long recruitId;
+}

--- a/src/main/java/org/hifivee/minebackend/domain/apply/dto/ApplyFetchRequestDto.java
+++ b/src/main/java/org/hifivee/minebackend/domain/apply/dto/ApplyFetchRequestDto.java
@@ -1,12 +1,11 @@
 package org.hifivee.minebackend.domain.apply.dto;
 
 import lombok.Data;
-import org.hifivee.minebackend.domain.account.repository.Account;
 
 @Data
 public class ApplyFetchRequestDto {
     // 특정 지원서
-    //private long id;
+    //private Long id;
 
     // 나의 지원서
     //private Long userId;
@@ -14,7 +13,7 @@ public class ApplyFetchRequestDto {
     // 구인글별 지원서
     //private Long recruitId;
 
-    private long id;
+    private Long id;
     private Long userId;
     private Long recruitId;
 }

--- a/src/main/java/org/hifivee/minebackend/domain/apply/dto/ApplyFetchResponseDto.java
+++ b/src/main/java/org/hifivee/minebackend/domain/apply/dto/ApplyFetchResponseDto.java
@@ -1,0 +1,23 @@
+package org.hifivee.minebackend.domain.apply.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.hifivee.minebackend.domain.apply.repository.Apply;
+import org.hifivee.minebackend.global.dto.DtoMetaData;
+
+import java.util.List;
+
+@Data
+public class ApplyFetchResponseDto {
+    List<Apply> applies;
+    DtoMetaData dtoMetaData;
+
+    public ApplyFetchResponseDto(DtoMetaData dtoMetaData, List<Apply> applies){
+        this.dtoMetaData = dtoMetaData;
+        this.applies = applies;
+    }
+
+    public ApplyFetchResponseDto(DtoMetaData dtoMetaData){
+        this.dtoMetaData = dtoMetaData;
+    }
+}

--- a/src/main/java/org/hifivee/minebackend/domain/apply/dto/ApplyUpdateRequestDto.java
+++ b/src/main/java/org/hifivee/minebackend/domain/apply/dto/ApplyUpdateRequestDto.java
@@ -1,0 +1,9 @@
+package org.hifivee.minebackend.domain.apply.dto;
+
+import lombok.Data;
+
+@Data
+public class ApplyUpdateRequestDto {
+    private Long id;
+    private String applyMessage;
+}

--- a/src/main/java/org/hifivee/minebackend/domain/apply/dto/ApplyUpdateResponseDto.java
+++ b/src/main/java/org/hifivee/minebackend/domain/apply/dto/ApplyUpdateResponseDto.java
@@ -1,0 +1,11 @@
+package org.hifivee.minebackend.domain.apply.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.hifivee.minebackend.global.dto.DtoMetaData;
+
+@Data
+@AllArgsConstructor
+public class ApplyUpdateResponseDto {
+    DtoMetaData dtoMetaData;
+}

--- a/src/main/java/org/hifivee/minebackend/domain/apply/repository/Apply.java
+++ b/src/main/java/org/hifivee/minebackend/domain/apply/repository/Apply.java
@@ -1,10 +1,14 @@
 package org.hifivee.minebackend.domain.apply.repository;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import net.bytebuddy.implementation.bind.annotation.BindingPriority;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import org.hifivee.minebackend.domain.account.repository.Account;
+import org.hifivee.minebackend.domain.recruit.repository.Recruit;
 
 import javax.persistence.*;
 
@@ -12,12 +16,14 @@ import javax.persistence.*;
 @NoArgsConstructor
 @Entity
 public class Apply {
+
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long applyId;
 
     @ManyToOne(targetEntity = Account.class, fetch = FetchType.LAZY)
     @OnDelete(action = OnDeleteAction.CASCADE)
-    @JoinColumn(name = "applyId", referencedColumnName = "id")
+    @JoinColumn(name = "userId", referencedColumnName = "id")
     Account account;
 
     @Column
@@ -28,4 +34,11 @@ public class Apply {
     @JoinColumn(name = "recruitId", referencedColumnName = "id")
     Recruit recruit;
 
+    @Builder
+    public Apply(Long applyId, Account account, String applyMessage, Recruit recruit){
+        this.applyId = applyId;
+        this.account = account;
+        this.applyMessage = applyMessage;
+        this.recruit = recruit;
+    }
 }

--- a/src/main/java/org/hifivee/minebackend/domain/apply/repository/Apply.java
+++ b/src/main/java/org/hifivee/minebackend/domain/apply/repository/Apply.java
@@ -1,38 +1,37 @@
 package org.hifivee.minebackend.domain.apply.repository;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import net.bytebuddy.implementation.bind.annotation.BindingPriority;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import org.hifivee.minebackend.domain.account.repository.Account;
 import org.hifivee.minebackend.domain.recruit.repository.Recruit;
+import org.hifivee.minebackend.global.entity.BaseEntity;
 
 import javax.persistence.*;
 
 @Getter
 @NoArgsConstructor
 @Entity
-public class Apply {
+public class Apply extends BaseEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    Long applyId;
+    private Long applyId;
 
-    @ManyToOne(targetEntity = Account.class, fetch = FetchType.LAZY)
+    @ManyToOne(targetEntity = Account.class, fetch = FetchType.EAGER)
     @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "userId", referencedColumnName = "id")
-    Account account;
+    private Account account;
 
     @Column
-    String applyMessage;
+    private String applyMessage;
 
-    @ManyToOne(targetEntity = Recruit.class, fetch = FetchType.LAZY)
+    @ManyToOne(targetEntity = Recruit.class, fetch = FetchType.EAGER)
     @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "recruitId", referencedColumnName = "id")
-    Recruit recruit;
+    private Recruit recruit;
 
     @Builder
     public Apply(Long applyId, Account account, String applyMessage, Recruit recruit){
@@ -40,5 +39,9 @@ public class Apply {
         this.account = account;
         this.applyMessage = applyMessage;
         this.recruit = recruit;
+    }
+
+    public void update(String applyMessage){
+        this.applyMessage = applyMessage;
     }
 }

--- a/src/main/java/org/hifivee/minebackend/domain/apply/repository/Apply.java
+++ b/src/main/java/org/hifivee/minebackend/domain/apply/repository/Apply.java
@@ -1,0 +1,31 @@
+package org.hifivee.minebackend.domain.apply.repository;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.hifivee.minebackend.domain.account.repository.Account;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Apply {
+    @Id
+    Long applyId;
+
+    @ManyToOne(targetEntity = Account.class, fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "applyId", referencedColumnName = "id")
+    Account account;
+
+    @Column
+    String applyMessage;
+
+    @ManyToOne(targetEntity = Recruit.class, fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "recruitId", referencedColumnName = "id")
+    Recruit recruit;
+
+}

--- a/src/main/java/org/hifivee/minebackend/domain/apply/repository/ApplyRepository.java
+++ b/src/main/java/org/hifivee/minebackend/domain/apply/repository/ApplyRepository.java
@@ -1,10 +1,16 @@
 package org.hifivee.minebackend.domain.apply.repository;
 
+import org.hifivee.minebackend.domain.account.repository.Account;
 import org.hifivee.minebackend.domain.project.repository.Project;
+import org.hifivee.minebackend.domain.recruit.repository.Recruit;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import java.util.List;
+
 @Repository
 public interface ApplyRepository extends JpaRepository<Apply, Long> {
+    List<Apply> findByAccount(Account account);
+    List<Apply> findByRecruit(Recruit recruit);
 }

--- a/src/main/java/org/hifivee/minebackend/domain/apply/repository/ApplyRepository.java
+++ b/src/main/java/org/hifivee/minebackend/domain/apply/repository/ApplyRepository.java
@@ -1,0 +1,10 @@
+package org.hifivee.minebackend.domain.apply.repository;
+
+import org.hifivee.minebackend.domain.project.repository.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Repository
+public interface ApplyRepository extends JpaRepository<Apply, Long> {
+}

--- a/src/main/java/org/hifivee/minebackend/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/hifivee/minebackend/domain/apply/service/ApplyService.java
@@ -3,15 +3,13 @@ package org.hifivee.minebackend.domain.apply.service;
 import lombok.RequiredArgsConstructor;
 import org.hifivee.minebackend.domain.account.repository.Account;
 import org.hifivee.minebackend.domain.account.repository.AccountRepository;
-import org.hifivee.minebackend.domain.apply.dto.ApplyCreateRequestDto;
-import org.hifivee.minebackend.domain.apply.dto.ApplyFetchRequestDto;
+import org.hifivee.minebackend.domain.apply.dto.*;
 import org.hifivee.minebackend.domain.apply.repository.Apply;
 import org.hifivee.minebackend.domain.apply.repository.ApplyRepository;
 import org.hifivee.minebackend.domain.recruit.repository.Recruit;
 import org.hifivee.minebackend.domain.recruit.repository.RecruitRepository;
 import org.springframework.stereotype.Service;
 
-import javax.transaction.TransactionScoped;
 import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
@@ -71,5 +69,21 @@ public class ApplyService {
         else{
             return applies;
         }
+    }
+
+    @Transactional
+    public void deleteApply(ApplyDeleteRequestDto requestDto) {
+        Apply apply = applyRepository.findById(requestDto.getId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 지원서가 없습니다"));
+
+        applyRepository.delete(apply);
+    }
+
+    @Transactional
+    public void updateApply(ApplyUpdateRequestDto requestDto) {
+        Apply apply = applyRepository.findById(requestDto.getId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 지원서가 없습니다"));
+
+        apply.update(requestDto.getApplyMessage());
     }
 }

--- a/src/main/java/org/hifivee/minebackend/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/hifivee/minebackend/domain/apply/service/ApplyService.java
@@ -1,0 +1,8 @@
+package org.hifivee.minebackend.domain.apply.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class ApplyService {
+
+}

--- a/src/main/java/org/hifivee/minebackend/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/hifivee/minebackend/domain/apply/service/ApplyService.java
@@ -1,8 +1,75 @@
 package org.hifivee.minebackend.domain.apply.service;
 
+import lombok.RequiredArgsConstructor;
+import org.hifivee.minebackend.domain.account.repository.Account;
+import org.hifivee.minebackend.domain.account.repository.AccountRepository;
+import org.hifivee.minebackend.domain.apply.dto.ApplyCreateRequestDto;
+import org.hifivee.minebackend.domain.apply.dto.ApplyFetchRequestDto;
+import org.hifivee.minebackend.domain.apply.repository.Apply;
+import org.hifivee.minebackend.domain.apply.repository.ApplyRepository;
+import org.hifivee.minebackend.domain.recruit.repository.Recruit;
+import org.hifivee.minebackend.domain.recruit.repository.RecruitRepository;
 import org.springframework.stereotype.Service;
 
-@Service
-public class ApplyService {
+import javax.transaction.TransactionScoped;
+import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
 
+@Service
+@RequiredArgsConstructor
+public class ApplyService {
+    private final AccountRepository accountRepository;
+    private final RecruitRepository recruitRepository;
+    private final ApplyRepository applyRepository;
+
+    @Transactional
+    public void createApply(ApplyCreateRequestDto requestDto){
+        Account userId = accountRepository.findById(requestDto.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("지원하는 유저 정보가 없습니다"));
+        Recruit recruitId = recruitRepository.findById(requestDto.getRecruitId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 구인글이 존재하지 않습니다."));
+
+        applyRepository.save(requestDto.toApply(userId, recruitId));
+    }
+
+    @Transactional
+    public List<Apply> fetchApply(ApplyFetchRequestDto requestDto) {
+        Apply apply = applyRepository.findById(requestDto.getId())
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 지원서가 없습니다."));
+        List<Apply> applies = new ArrayList<>();
+        applies.add(apply);
+
+        return applies;
+    }
+
+    @Transactional
+    public List<Apply> fetchMyApply(ApplyFetchRequestDto requestDto) {
+        Account userId = accountRepository.findById(requestDto.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저 정보가 없습니다"));
+
+        List<Apply> applies = applyRepository.findByAccount(userId);
+
+        if(applies.isEmpty()){
+            return null;
+        }
+        else{
+            return applies;
+        }
+    }
+
+    @Transactional
+    public List<Apply> fetchRecuritApply(ApplyFetchRequestDto requestDto) {
+        Recruit recruitId = recruitRepository.findById(requestDto.getRecruitId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 구인글이 없습니다"));
+
+        List<Apply> applies = applyRepository.findByRecruit(recruitId);
+
+        if(applies.isEmpty()){
+            return null;
+        }
+        else{
+            return applies;
+        }
+    }
 }

--- a/src/main/resources/application-dev-komputer.properties
+++ b/src/main/resources/application-dev-komputer.properties
@@ -1,7 +1,0 @@
-# 환경 변수 - 박지환의 개발 환경 기준
-
-# MySQL 설정
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=jdbc:mysql://localhost:3306/mine?characterEncoding=UTF-8
-spring.datasource.username=hifivee
-spring.datasource.password=hifivee

--- a/src/main/resources/application-nig.properties
+++ b/src/main/resources/application-nig.properties
@@ -1,0 +1,6 @@
+# NaInGyu ?? ???? ??
+
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://localhost:3306/mine?characterEncoding=UTF-8
+spring.datasource.username=hifivee
+spring.datasource.password=Hifivee1234

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,7 +23,5 @@ jwt.secret=aGlmaXZlZS1taW5lLWJhY2tlbmQtc2VydmVyLXNwcmluZy1zZWN1cml0eS13aXRoLWp3d
 # TOKEN VALIDITY, (Milliseconds): 30분
 jwt.token-expire-time=1800000
 
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=jdbc:mysql://localhost:3306/mine?characterEncoding=UTF-8
-spring.datasource.username=hifivee
-spring.datasource.password=Hifivee1234
+#Add db id and password
+spring.profiles.include=nig

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,6 +22,3 @@ spring.mail.properties.mail.smtp.starttls.enable=true
 jwt.secret=aGlmaXZlZS1taW5lLWJhY2tlbmQtc2VydmVyLXNwcmluZy1zZWN1cml0eS13aXRoLWp3dC1zZWNyZXQtZm9yLXRva2VuCg==
 # TOKEN VALIDITY, (Milliseconds): 30분
 jwt.token-expire-time=1800000
-
-#Add db id and password
-spring.profiles.include=nig


### PR DESCRIPTION
## 개요
### PR 종류
 - [x] 기능 구현을 위한 소스코드 수정 (PR제목 양식: "[feature/브랜치명] 제목", 브랜치작명법: "feature/명칭" 사용)
 - [ ] 버그 수정을 위한 소스코드 수정 (PR제목 양식: "[hotfix/브랜치명] 제목", 브랜치작명법: "hotfix/명칭" 사용)

## 작업내용
- 지원서 도메인 기본 CRUD 구현

## 변경사항
- Apply Domain
   - REST API 설계 가이드라인을 바탕으로 Apply CRUD API 엔드포인트를 구현
      - 지원서 생성(POST)
      - 지원서 조회(GET)
         - 특정 지원서 조회
         - 내가 쓴 지원서 조회
         - 구인별 지원서 조회
      - 지원서 수정(PUT)
      - 지원서 삭제(DELETE)
 
## 비고
- Postman에 관련 테스트를 추가